### PR TITLE
Fix problem with processing images multiple times

### DIFF
--- a/optimizer.js
+++ b/optimizer.js
@@ -170,7 +170,7 @@ function processNext() {
   }
 
   // Process the next key in the queue
-  key = keys.pop();
+  key = keys.shift();
   // numTasks++;
   processOne(key, function() {
     // numTasks--;


### PR DESCRIPTION
The keys were being processed from the bottom to the top. This means that when requesting the next page, the markerFile will always be the top key from the last set of keys. This effectively causes the pagination to only move down 1 index at a time, causing the rest of the keys to be duplicates.
