### PR TITLE
Update to new version of nodejs runtime (nodejs4.3)

### DIFF
--- a/.env
+++ b/.env
@@ -10,6 +10,8 @@ AWS_HANDLER=index.optimizer
 AWS_MEMORY_SIZE=1536
 AWS_TIMEOUT=300
 
+AWS_RUNTIME=nodejs4.3
+
 SOURCE_BUCKET=bluethumb-art-uploads
 UPLOAD_BUCKET=bluethumb-art-uploads-optim
 UPLOAD_ACL=public-read


### PR DESCRIPTION
The existing version of nodejs runtime has been depreciated and deployment was failing with current config. Was getting the following error:
[InvalidParameterValueException: The runtime parameter of nodejs is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (nodejs4.3) while creating or updating functions.]
  message: 'The runtime parameter of nodejs is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (nodejs4.3) while creating or updating functions.',
  code: 'InvalidParameterValueException'